### PR TITLE
bug(Activation) Update host on production for mailers

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,6 +63,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "game_shelf_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: 'gameshelf.online' }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
### What is this
This fixes a bug in generating urls for emails. Turns out I had the host set to `gameshelf` for ActionMailer. One production this should be `gameshelf.online`.