### PR TITLE
chore(dips): Bump bundler to 2.6.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,4 +470,4 @@ RUBY VERSION
    ruby 3.3.0p0
 
 BUNDLED WITH
-   2.1.4
+   2.6.6


### PR DESCRIPTION
Removes depreciation warnings.